### PR TITLE
Add bugs and repo URL to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,13 @@
 {
   "name": "quad-shader",
   "version": "0.0.5",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nmattia/quad-shader.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nmattia/quad-shader"
+  },
   "type": "module",
   "files": [
     "README.md",


### PR DESCRIPTION
The repo url is useful for displaying a link on the npm's library page.