### PR TITLE
Fix description on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "quad-shader",
   "version": "0.0.5",
+  "description": "Zero-deps library for creating WebGL-based applications using Vite and TypeScript",
   "type": "module",
   "files": [
     "README.md",


### PR DESCRIPTION
Add a description field to package.json to fix the metadata on npm.

<img width="1533" height="1034" alt="Capture d’écran 2025-10-03 à 07 01 36" src="https://github.com/user-attachments/assets/ae9ec5aa-dfd5-4294-bbda-79cb6c11898f" />
